### PR TITLE
Travis CI for mini-tcl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+services:
+  - docker
+
+env:
+  DOCKER_COMPOSE_VERSION: 1.5.2
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+script:
+  - docker-compose build
+  - docker-compose up -d
+  - docker-compose ps
+  - docker-compose run --entrypoint tclsh8.6 tclsh-service /opt/tcl/lib/test/tls.test.tcl

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mini-tcl
+# mini-tcl [![Build Status](https://travis-ci.org/muenchhausen/mini-tcl.svg?branch=master)](https://travis-ci.org/muenchhausen/mini-tcl)
 An Alpine Linux based mini Tcl for Docker.
 
 This contains a restricted set of packages necessary for running Tcl 8.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+tclsh-service:
+  image: efrecon/mini-tcl
+  entrypoint: /bin/sh
+  command: -c "echo 'puts stderr helloworld' | tclsh8.6"
+  volumes:
+    - ./test:/opt/tcl/lib/test

--- a/test/tls.test.tcl
+++ b/test/tls.test.tcl
@@ -1,3 +1,5 @@
+# Maintainer Derk Muenchhausen <derk@muenchhausen.de>
+
 package require tcltest
 package require tls
 package require http

--- a/test/tls.test.tcl
+++ b/test/tls.test.tcl
@@ -1,0 +1,19 @@
+package require tcltest
+package require tls
+package require http
+namespace import -force ::tcltest::*
+
+test https_request_shall_return_HTTP_OK {} -body {
+
+	::http::register https 443 [list ::tls::socket -request 1 -ssl2 0 -ssl3 0 -tls1 1]
+	set token [::http::geturl https://github.com]
+	set status [::http::status $token]
+	::http::cleanup $token
+	return $status
+
+} -result "ok"
+
+array set testResult [array get ::tcltest::numTests]
+cleanupTests
+
+exit $testResult(Failed)


### PR DESCRIPTION
Dear Emmanuel,
thanks, I liked your simple Tcl container!
I was playing around with Travis. Using Docker, it is quite simple to add Tcl tests :) If you take over this pull request, please change the Travis URL in README.md to your account:
https://travis-ci.org/muenchhausen/mini-tcl.svg?branch=master
https://travis-ci.org/efrecon/mini-tcl.svg?branch=master
best regards,
Derk
